### PR TITLE
adding screen and file logging to 7-BM scans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,115 @@
+# Byte-compiled / optimized / DLL files #
+#########################################
+__pycache__/
+*.py[cod]
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+.spyderworkspace
+*.*~
+
+# Python pyproducts #
+#####################
+*.pyc
+build
+dist
+docs/build
+*egg-info
+*.egg
+.settings
+
+# LaTex generated files #
+#########################
+*.aux
+*.cls
+*.layout
+*.bst
+*.lof
+*.toc
+*.out
+*.bbl
+*.blg
+
+# Test files #
+##############
+test.py
+main.py
+
+# Distribution / packaging #
+############################
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+.installed.cfg
+
+# Installer logs #
+##################
+pip-log.txt
+
+# Unit test / coverage reports #
+################################
+.tox/
+.coverage
+nosetests.xml
+coverage.xml
+
+# Translations #
+################
+*.mo
+
+# Mr Developer #
+################
+.mr.developer.cfg
 .project
 .pydevproject
+*.sublime-project
+*.sublime-workspace
+docs/trunk/*
+
+# Credentials #
+###############
+credentials.ini
+*.conf
+

--- a/log_lib.py
+++ b/log_lib.py
@@ -1,0 +1,56 @@
+'''
+    Log Lib for Sector 2-BM 
+    
+'''
+import logging
+
+# Logging defines
+__GREEN = "\033[92m"
+__RED = '\033[91m'
+__YELLOW = '\033[33m'
+__ENDC = '\033[0m'
+
+
+logger = None
+info_extra={'endColor': __ENDC, 'color': __GREEN}
+warn_extra={'endColor': __ENDC, 'color': __YELLOW}
+error_extra={'endColor': __ENDC, 'color': __RED}
+
+def info(msg):
+    global logger
+    global info_extra
+    logger.info(msg, extra=info_extra)
+
+def error(msg):
+    global logger
+    global error_extra
+    logger.error(msg, extra=error_extra)
+
+def warning(msg):
+    global logger
+    global warn_extra
+    logger.warning(msg, extra=warn_extra)
+
+
+def setup_logger(log_name, stream_to_console=True):
+    global logger
+    global info_extra
+    global warn_extra
+    global error_extra
+
+    info_extra['logger_name'] = log_name
+    warn_extra['logger_name'] = log_name
+    error_extra['logger_name'] = log_name
+    logger = logging.getLogger(log_name)
+    fHandler = logging.FileHandler(log_name)
+    logger.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(asctime)s %(color)s  %(message)s %(endColor)s")
+    fHandler.setFormatter(formatter)
+    logger.addHandler(fHandler)
+    if stream_to_console:
+        ch = logging.StreamHandler()
+        ch.setFormatter(formatter)
+        ch.setLevel(logging.DEBUG)
+        logger.addHandler(ch)
+
+

--- a/log_lib.py
+++ b/log_lib.py
@@ -1,5 +1,5 @@
 '''
-    Log Lib for Sector 2-BM 
+    Log Lib for 7-BM 
     
 '''
 import logging

--- a/mct.xml
+++ b/mct.xml
@@ -151,6 +151,19 @@
           </group><!-- /setup -->
         </group><!-- /detector -->
       </group><!-- /instrument -->
+
+    <group name="sample">
+      <group name="experimenter">
+         <dataset name="name" source="ndattribute" ndattribute="UserName" when="OnFileClose" />
+         <dataset name="affiliation" source="ndattribute" ndattribute="UserAffiliation" when="OnFileClose" />
+         <dataset name="email" source="ndattribute" ndattribute="UserEmail" when="OnFileClose" />
+         <dataset name="facility_user_id" source="ndattribute" ndattribute="UserBadge" when="OnFileClose" />
+      </group><!-- /experimenter -->
+      <group name="experiment">
+         <dataset name="proposal" source="ndattribute" ndattribute="ProposalNumber" when="OnFileClose" />
+         <dataset name="title" source="ndattribute" ndattribute="ProposalTitle" when="OnFileClose" />
+      </group><!-- /experiment -->
+    </group><!-- /sample -->
       
       <group name="ancillary">
         <dataset name="MW100_ADC_01" source="ndattribute" ndattribute="MW100_ADC_01" when="OnFrame"> 

--- a/mctDetectorAttributes.xml
+++ b/mctDetectorAttributes.xml
@@ -90,6 +90,14 @@
     <Attribute name="MW100_ADC_08_Desc"               type="EPICS_PV" source="7bm_dau1:dau:008:Label"       dbrtype="DBR_STRING"/>
     <Attribute name="MW100_ADC_09_Desc"               type="EPICS_PV" source="7bm_dau1:dau:009:Label"       dbrtype="DBR_STRING"/> 
     <Attribute name="MW100_ADC_10_Desc"               type="EPICS_PV" source="7bm_dau1:dau:010:Label"       dbrtype="DBR_STRING"/>
+
+    <Attribute name="UserName"                        type="EPICS_PV" source="7bmb1:ExpInfo:UserName"          dbrtype="DBR_STRING"/>
+    <Attribute name="UserAffiliation"                 type="EPICS_PV" source="7bmb1:ExpInfo:UserInstitution"   dbrtype="DBR_STRING"/>
+    <Attribute name="UserBadge"                       type="EPICS_PV" source="7bmb1:ExpInfo:UserBadge"         dbrtype="DBR_STRING"/>
+    <Attribute name="UserEmail"                       type="EPICS_PV" source="7bmb1:ExpInfo:UserEmail"         dbrtype="DBR_STRING"/>
+    <Attribute name="ProposalNumber"                  type="EPICS_PV" source="7bmb1:ExpInfo:ProposalNumber"    dbrtype="DBR_STRING"/>
+    <Attribute name="ProposalTitle"                   type="EPICS_PV" source="7bmb1:ExpInfo:ProposalTitle"     dbrtype="DBR_STRING"/>
+
   
 </Attributes>
     


### PR DESCRIPTION
to use log_lib.py after accepting this pull request:

- if not already available install  the following python library 
   - logging
   - os
   - datetime

- in your main scan function (I think this will be one of the fly scan function or perhaps the daemon)

```
from datetime import datetime
import os
import log_lib

...

def your_main_scan_function():

   # set the home directory for the log files
    home = os.path.expanduser("~")
    logs_home = home + '/logs/'

    # make sure logs directory exists
    if not os.path.exists(logs_home):
        os.makedirs(logs_home)

   # set the log file name
    lfname = logs_home + 'aps_7bm_tomo' + datetime.strftime(datetime.now(), "%Y-%m-%d_%H:%M:%S") + '.log'
    log_lib.setup_logger(lfname)
```

- replace all print with one of these:

```
    log_lib.info('This will print in green')
    log_lib.warning('This will print in yellow')
    log_lib.error('This will print in red')
```
